### PR TITLE
Bug Fix: Updating changed assignment/category info properly syncs

### DIFF
--- a/scripts/processToIC.ps1
+++ b/scripts/processToIC.ps1
@@ -570,6 +570,7 @@ try {
         ,   xca.dueDate = xia.dueDate
         ,   xca.pointsPossible = xia.pointsPossible
         ,   xca.seq = xia.seq
+        ,   xca.canvasCategoryID = xia.canvasCategoryID
     WHEN NOT MATCHED BY SOURCE THEN 
     DELETE
     WHEN NOT MATCHED BY TARGET THEN


### PR DESCRIPTION
Fixed bug where an assignment category would not change if updated after it had already been synced.